### PR TITLE
Adds support for ZSH shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ WIP.
 
 ## How to Install?
 
-1. Add `source /path/to/d2/exe/d2.sh` to your `.bash_profile`, `.bashrc`, etc.
+1. Add `source /path/to/d2/exe/d2.sh` to your `.bash_profile`, `.bashrc`, `.zshrc`, etc.
 2. Restart your terminal.
 3. Run `d2 help` to see what is available.
 

--- a/exe/d2.sh
+++ b/exe/d2.sh
@@ -1,14 +1,28 @@
-#!/bin/bash
+#!/bin/sh
 
 # Export the directory to d2.sh here so that the shell function
 # can access the exe file anywhere in the system. If we didn't do this here,
 # BASH_SOURCE would constantly change as we moved around the system
-export D2_SH_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+#!/bin/sh
+if [ -n "$ZSH_VERSION" ]; then
+  export D2_SH_DIR="$( cd "$( dirname "${(%):-%N}" )" >/dev/null 2>&1 && pwd )"
 
-if [ "$(type -t dev)" != 'function' ]; then
-  dev(){
-    alias dev=d2
-  }
+  if [ "$(whence -w dev)" != 'dev: function' ]; then
+    dev(){
+      alias dev=d2
+    }
+  fi
+elif [ -n "$BASH_VERSION" ]; then
+  export D2_SH_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+  if [ "$(type -t dev)" != 'function' ]; then
+    dev(){
+      alias dev=d2
+    }
+  fi
+else
+  echo "Unknown shell. Exiting"
+  exit(1)
 fi
 
 d2() {

--- a/lib/d2/commands/cd.rb
+++ b/lib/d2/commands/cd.rb
@@ -21,7 +21,7 @@ module D2
           )
 
           if options.empty?
-            logger.info "Nothing found for #{args.first}"
+            logger.info "Nothing found for '#{query}'"
             return
           end
           File.join(base_path, options.first)


### PR DESCRIPTION
I use ZSH and the setup script wasn't quite working so I made some quick adjustments to it to support it.  There may be better ways to do this, I am a somewhat rusty when it comes to shell scripts.

* Added a BASH and ZSH conditional check
* added ZSH equivalent for `dirname "${BASH_SOURCE[0]}`
* added ZSH equivalent for ` "$(type -t dev)" `

Additionally updated the error message when the `cd` command cannot find the project